### PR TITLE
FF-221: Entity accessibility errors

### DIFF
--- a/proto/fistful.thrift
+++ b/proto/fistful.thrift
@@ -42,6 +42,9 @@ exception DestinationNotFound       {}
 exception DepositNotFound           {}
 exception SourceUnauthorized        {}
 exception PartyInaccessible         {}
+exception WalletInaccessible {
+    1: required WalletID id
+}
 exception ProviderNotFound          {}
 exception IdentityClassNotFound     {}
 exception ChallengeNotFound         {}

--- a/proto/w2w_transfer.thrift
+++ b/proto/w2w_transfer.thrift
@@ -146,6 +146,7 @@ service Management {
             2: fistful.InvalidOperationAmount ex2
             3: fistful.ForbiddenOperationCurrency ex3
             4: InconsistentW2WTransferCurrency ex4
+            5: fistful.WalletInaccessible ex5
         )
 
     W2WTransferState Get(

--- a/proto/withdrawal.thrift
+++ b/proto/withdrawal.thrift
@@ -252,8 +252,6 @@ exception AnotherAdjustmentInProgress {
     1: required AdjustmentID another_adjustment_id
 }
 
-exception WalletInaccessible {}
-
 service Management {
 
     Quote GetQuote(
@@ -284,7 +282,7 @@ service Management {
             8: InconsistentWithdrawalCurrency ex8
             9: NoDestinationResourceInfo ex9
             10: IdentityProvidersMismatch ex10 
-            11: WalletInaccessible ex11
+            11: fistful.WalletInaccessible ex11
         )
 
     WithdrawalState Get(


### PR DESCRIPTION
Для контекста: этот PR добавляет thrift поддержку ошибок доступности, введенных в https://github.com/rbkmoney/fistful-server/pull/289