### PR TITLE
FF206: Identity name via thrift

### DIFF
--- a/proto/identity.thrift
+++ b/proto/identity.thrift
@@ -43,18 +43,6 @@ struct IdentityParams {
 
 struct Identity {
     6:  optional IdentityID  id
-    12: required string      name
-    1:  required PartyID     party
-    2:  required ProviderID  provider
-    3:  required ClassID     cls
-    4:  optional ContractID  contract
-    5:  optional ExternalID  external_id
-    10: optional Timestamp   created_at
-    11: optional ContextSet  metadata
-}
-
-struct Identity_v1 {
-    6:  optional IdentityID  id
     12: optional string      name //will become required after migration!
     1:  required PartyID     party
     2:  required ProviderID  provider
@@ -219,7 +207,7 @@ struct TimestampedChange {
 }
 
 union Change {
-    1: Identity_v1     created
+    1: Identity        created
     2: LevelID         level_changed
     3: ChallengeChange identity_challenge
     4: ChallengeID     effective_challenge_changed


### PR DESCRIPTION
На данный момент кажется возможным сделать name required для IdentityState и Params. CreateIdentity будет получать нейм в параметрах вместо контекста и сохранять его в ивент в опциональное поле и в контекст. GetIdentity будет пытаться читать данные из ивента, и если там нейм undefined то брать его из контекста. Потом миграцией можно дозаписать все undefined, если я правильно понял.