### PR TITLE
Fix js client compilation conflict

### DIFF
--- a/proto/deposit.thrift
+++ b/proto/deposit.thrift
@@ -174,7 +174,7 @@ exception RevertNotFound {
     1: required RevertID id
 }
 
-service Management {
+service DepositManagement {
 
     DepositState Create(
         1: DepositParams params

--- a/proto/wallet.thrift
+++ b/proto/wallet.thrift
@@ -79,7 +79,7 @@ union AccountChange {
 
 ///
 
-service Management {
+service WalletManagement {
     WalletState Create (
         1: WalletParams params
         2: context.ContextSet context


### PR DESCRIPTION
Под каждый сервис js thrift компилятор гененирует отдельный js файл. Файлу называет именем сервиса. В данном случае будет два `Management.js`. Содержимое перетирается :)

Посмотрите насколько такие изменения возможны и нужно ли с вашей стороны доп действия